### PR TITLE
If ClientIp is set by x_forwarded_for in the header, require_ip_address throws badarg errors.

### DIFF
--- a/src/lib/cb_admin_lib.erl
+++ b/src/lib/cb_admin_lib.erl
@@ -16,7 +16,8 @@ mask_ipv4_address({I1, I2, I3, I4}, MaskInt) ->
 require_ip_address(Req) ->
     ClientIp = case Req:header(x_forwarded_for) of
         undefined -> Req:peer_ip();
-        IP -> list_to_tuple(lists:map(fun erlang:list_to_integer/1, string:tokens(IP, ".")))
+        IP when is_tuple(IP)-> IP;
+        IP when is_list(IP) -> list_to_tuple(lists:map(fun erlang:list_to_integer/1, string:tokens(IP, ".")))
     end,
     Authorized = lists:foldr(fun
             (IPBlock, false) ->


### PR DESCRIPTION
ClientIp from Req:peer_ip/0 is a tuple, ClientIp from Req:header/1 is a string.

Convert the string to a tuple?
