### PR TITLE
Handle list of bitstrings present in model, quite common for mongodb

### DIFF
--- a/src/view/model/edit.html
+++ b/src/view/model/edit.html
@@ -12,13 +12,21 @@
 {% endif %}
 <form name="edit" action="{% url action="edit" record_id=record.id %}" method="post">
 <table>
-    {% for key, val in record.attributes %}
+    {% for key, val, datatype in attributes %}
     {% ifnotequal key "id" %}
-    {% if "_time" in key %}
+    {% if datatype == "datetime" %}
     <tr><td>{{ key }}</td><td><input type="radio" name="{{ key }}" value="now" id="{{ key }}_now" /><label for="{{ key }}_now">Now</label>
             &nbsp; <input type="radio" name="{{ key }}" value="null" id="{{ key }}_null" checked="checked" /><label for="{{ key }}_null">{% if val %}{{ val|date }} {{ val|time }}{% else %}Null{% endif %}</label>
     {% else %}
+    {% if  datatype == "lists" %}
+    <tr><td><label for="{{ key }}_textarea">{{ key }}</label></td><td><textarea id="{{ key }}_textarea" name="{{ key }}">
+    {% for elem in val %}{{ elem|escape }},{%endfor %}
+
+    </textarea></td></tr>
+
+    {% else %}
     <tr><td><label for="{{ key }}_textarea">{{ key }}</label></td><td><textarea id="{{ key }}_textarea" name="{{ key }}">{{ val|escape }}</textarea></td></tr>
+    {% endif %}
     {% endif %}
     {% endifnotequal %}
     {% endfor %}

--- a/src/view/model/model.html
+++ b/src/view/model/model.html
@@ -60,7 +60,15 @@
             {% if datatype == "string" or datatype == "binary" %}
             <td id="{{ record_id }}-{{ key }}">{{ val|truncatewords:8 }}</td>
             {% else %}
+            {% if datatype == "lists" %}
+            <td id="{{ record_id }}-{{ key }}">
+            {% for elem in val %}
+                {{elem}} ,
+                {% endfor %}
+            </td>
+            {% else %}
             <td id="{{ record_id }}-{{ key }}">{{ val }}</td>
+            {% endif %}
             {% endif %}
             {% endif %}
             {% endif %}

--- a/src/view/model/show.html
+++ b/src/view/model/show.html
@@ -31,7 +31,15 @@
         {% if datatype == "string" or datatype == "binary" %}
         <span id="{{ record.id }}-{{ key }}">{{ val|linebreaksbr }}</span>
         {% else %}
+        {% if datatype == "lists" %}
+        <span id="{{ record.id }}-{{ key }}">
+        {% for elem in val %}
+        {{elem}} ,
+        {% endfor %}
+        </span>
+        {% else %}
         <span id="{{ record.id }}-{{ key }}">{{ val }}</span>
+        {% endif %}
         {% endif %}
         {% endif %}
         <br /><br />
@@ -62,7 +70,7 @@
     </tr>
     </table><br /><br />
     {% endif %}
-    {% endfor %} 
+    {% endfor %}
     <form name="delete" action="{% url action="delete" record_id=record.id %}">
         <input type="submit" value="Delete {{ record.id }}?" />
     </form>


### PR DESCRIPTION
Currently there was no way to edit and update list of strings
this has been taken care of by
1. adding a metadata called list fields in the model
2. all list fields are displayed in csv format
3. when editing the list fields will be split by comma and then pushed
to db

Signed-off-by: himangshu himangshuj@live.com
