### PR TITLE
Add word-break: break-all; for all html tables. 

### DIFF
--- a/priv/static/stylesheets/application.css
+++ b/priv/static/stylesheets/application.css
@@ -213,7 +213,9 @@ table.list thead th {
 table.list th a { font-weight:normal; color:#555;  }
 /* Issues grid styles by priorities (provided by Wynn Netherland) */
 table.list tr.issue a { color: #3c3c3c; }
-
+table {
+    word-break: break-all;
+}
 
 p.breadcrumb {
 	background-color:#EEEEEE;


### PR DESCRIPTION
To prevent content flowing over div's

Before:
![screen shot 2014-12-07 at 12 49 31](https://cloud.githubusercontent.com/assets/584394/5331140/f2cdf46a-7e12-11e4-8bf3-a02461115167.png)

After:
![screen shot 2014-12-07 at 13 03 12](https://cloud.githubusercontent.com/assets/584394/5331144/fc5fe72c-7e12-11e4-846f-c3cd57531712.png)
